### PR TITLE
fixed Chrome warning about importing scripts from unauthenticated sources

### DIFF
--- a/config/_variables.scss
+++ b/config/_variables.scss
@@ -2,7 +2,7 @@
  * Fonts
  * ------------------------------------- */
 // Google fonts
-@import url("http://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Raleway:400,100,300,700,500");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Raleway:400,100,300,700,500");
 $base-font: "Open Sans", "Helvetica", "sans-serif";
 $header-font: "Raleway", "Helvetica", "sans-serif";
 


### PR DESCRIPTION
I just started a project and used these stylesheets as a base.

When I deployed to Production Google Chrome was throwing the warning "This page is trying to load scripts from unauthenticated sources".

Turns out it must have updated its policies and now "http://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Raleway:400,100,300,700,500" is seen as unsafe.

Just made it https.

@Papillard, just realized I forgot to assign the PR to you!
