### PR TITLE
Move vendors import outside of YOUR CSS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Look at your main `application.scss` file to see how SCSS files are imported.
 @import "bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "vendor/index";
 
 // Your CSS
 @import "layout/index";
 @import "components/index";
 @import "pages/index";
-@import "vendor/index";
 ```
 
 For every folder (**`components`**, **`layout`**, **`pages`**, **`vendor`**), there is one `_index.scss` partial which is responsible for importing all the other partials of its folder.

--- a/application.scss
+++ b/application.scss
@@ -7,9 +7,9 @@
 @import "bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "vendor/index";
 
 // Your CSS
 @import "layout/index";
 @import "components/index";
 @import "pages/index";
-@import "vendor/index";


### PR DESCRIPTION
Poposal to move `@import "vendors/index"` outside of "YOUR CSS" section since it's CSS that comes from an outside source. 