### PR TITLE
Add complete path for application.scss in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ And the viewport in the layout
 Look at your main `application.scss` file to see how SCSS files are imported. There should **not** be a `*= require_tree .` line in the file.
 
 ```scss
+// app/assets/stylesheets/application.scss
+
 // Graphical variables
 @import "config/fonts";
 @import "config/colors";


### PR DESCRIPTION
Some students are not already familiar with rails' project structure, so they don't know where to find `application.scss`.