### PR TITLE
Add ellipsis (or something similar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ And the viewport in the layout
 ```html
 <!-- app/views/layouts/application.html.erb -->
 <head>
-  <!-- Add these line for detecting device width -->
+  ...
+  <!-- Add these lines for detecting device width -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 </head>


### PR DESCRIPTION
Currently a member of Batch 94 in Tokyo. While working through this setup for today's challenge, I assumed that the entire head of my layout should be replaced with 

<!-- Add these line for detecting device width -->
<meta name="viewport" content="width=device-width, initial-scale=1">
<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

This got me into trouble as bootstrap would not work without the original code between the head tags.

Adding an ellipsis (...) or something similar after the open tag and before "<!-- Add these lines..." would reinforce to the user that they're not supposed to touch the code that's currently there, just to add "<meta name=..." and "<meta http..."