### PR TITLE
Fix bootstrap variable names

### DIFF
--- a/config/_bootstrap_variables.scss
+++ b/config/_bootstrap_variables.scss
@@ -1,5 +1,5 @@
 // This is where you override default Bootstrap variables
-// 1. All Bootstrap variables are here => https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss
+// 1. All Bootstrap variables are here => https://github.com/twbs/bootstrap/blob/master/scss/_variables.scss
 // 2. These variables are defined with default value (see https://robots.thoughtbot.com/sass-default)
 // 3. You can override them below!
 
@@ -10,16 +10,16 @@ $body-bg:                 $light-gray;
 $font-size-base: 1rem;
 
 // Colors
-$gray-base:       $gray;
-$brand-primary:   $blue;
-$brand-success:   $green;
-$brand-info:      $yellow;
-$brand-danger:    $red;
-$brand-warning:   $orange;
+$body-color: $gray;
+$primary:    $blue;
+$success:    $green;
+$info:       $yellow;
+$danger:     $red;
+$warning:    $orange;
 
 // Buttons & inputs' radius
-$border-radius-base:  2px;
-$border-radius-large: 2px;
-$border-radius-small: 2px;
+$border-radius:    2px;
+$border-radius-lg: 2px;
+$border-radius-sm: 2px;
 
 // Override other variables below!


### PR DESCRIPTION
Variables names have changed between Bootstrap 3 and Bootstrap 4.
In this pull request, I renamed the variables according to Bootstrap 4.

I also changed the link from `bootstrap-sass` to the **original** bootstrap repository.

Note that I didn't change the values but you might want to update the `border-radius` ones. I see that on the UI Kit, you mostly use `4px`.
