### PR TITLE
Add missing gem for webpacker into the Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ensure you have the following gems in your Rails `Gemfile`
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 5.6.1'
 gem 'simple_form'
+gem 'webpacker', '~> 4.x'
 ```
 
 In your terminal, generate SimpleForm Bootstrap config.


### PR DESCRIPTION
The following line: `const { environment } = require('@rails/webpacker')` requires webpacker but it is missing from the above steps for the Gemfile