### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,7 @@ Finally import bootstrap:
 // app/javascript/packs/application.js
 import 'bootstrap';
 ```
-And add this to `application.html.erb`
-```erb
-<!-- app/views/layouts/application.html.erb -->
 
-  <!-- [...] -->
-
-  <%= javascript_include_tag "application" %> <!-- from app/assets/javascripts/application.js -->
-  <%= javascript_pack_tag "application" %>    <!-- from app/javascript/packs/application.js -->
-</body>
-```
 ## Adding new `.scss` files
 
 Look at your main `application.scss` file to see how SCSS files are imported. There should **not** be a `*= require_tree .` line in the file.


### PR DESCRIPTION
we don't need `application.js` from asset pipeline anymore in rails 6