### PR TITLE
Remove autoprefixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Ensure you have the following gems in your Rails `Gemfile`
 
 ```ruby
 # Gemfile
-gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 5.6.1'
 gem 'simple_form'
 ```


### PR DESCRIPTION
`autoprefixer-rails` is now deprecated and for some students that followed this guide linked from *Yelp MVC* challenge the attempt to build assets ends up in Rails crashing (on Node > 14)