### PR TITLE
Update readme to use Bootstrap 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ unzip stylesheets.zip -d app/assets && rm stylesheets.zip && mv app/assets/rails
 
 **On Ubuntu/Windows**: if the `unzip` command returns an error, please install it first by running `sudo apt install unzip`.
 
+Note that when you update the colors in `config/colors`, the (text) color of your buttons might change from white to black. This is done automatically by Bootstrap using the [WCAG 2.0 algorithm](https://getbootstrap.com/docs/5.1/customize/sass/#color-contrast) which makes sure that the contrast between the text and the background color meets accessibility standards.
+
 
 ## Bootstrap JS
 
@@ -71,8 +73,6 @@ Look at your main `application.scss` file to see how SCSS files are imported. Th
 @import "components/index";
 @import "pages/index";
 ```
-
-Note that the (text) color of your buttons might change from white to black when you update the colors in `config/colors`. This is done automatically by Bootstrap using the [WCAG 2.0 algorithm](https://getbootstrap.com/docs/5.1/customize/sass/#color-contrast) which makes sure that the contrast between the text and the background color meets accessibility standards.
 
 For every folder (**`components`**, **`pages`**), there is one `_index.scss` partial which is responsible for importing all the other partials of its folder.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ rails new APP_NAME
 Ensure you have bootstrap and it's dependencies
 
 ```bash
-yarn add bootstrap@4.6 jquery popper.js
+yarn add bootstrap @popperjs/core
 ```
 
 Ensure you have the following gems in your Rails `Gemfile`
@@ -28,6 +28,8 @@ bundle install
 rails generate simple_form:install --bootstrap
 ```
 
+Replace **all the content** of your `config/initializers/simple_form_bootstrap.rb` file with [this](https://github.com/heartcombo/simple_form-bootstrap/blob/main/config/initializers/simple_form_bootstrap.rb).
+
 Then replace Rails' stylesheets by Le Wagon's stylesheets:
 
 ```
@@ -38,41 +40,10 @@ unzip stylesheets.zip -d app/assets && rm stylesheets.zip && mv app/assets/rails
 
 **On Ubuntu/Windows**: if the `unzip` command returns an error, please install it first by running `sudo apt install unzip`.
 
-And the viewport in the layout
-
-```html
-<!-- app/views/layouts/application.html.erb -->
-<head>
-  <!-- Add these line for detecting device width -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-
-  <!-- [...] -->
-</head>
-```
 
 ## Bootstrap JS
 
-Make sure you change the webpack config with the following code to include jQuery & Popper in webpack:
-
-```js
-// config/webpack/environment.js
-const { environment } = require('@rails/webpacker')
-
-// Bootstrap 4 has a dependency over jQuery & Popper.js:
-const webpack = require('webpack')
-environment.plugins.prepend('Provide',
-  new webpack.ProvidePlugin({
-    $: 'jquery',
-    jQuery: 'jquery',
-    Popper: ['popper.js', 'default']
-  })
-)
-
-module.exports = environment
-```
-
-Finally import bootstrap:
+Import bootstrap:
 
 ```js
 // app/javascript/packs/application.js
@@ -100,6 +71,8 @@ Look at your main `application.scss` file to see how SCSS files are imported. Th
 @import "components/index";
 @import "pages/index";
 ```
+
+Note that the text color of your buttons might change from white to black when you update the colors in `config/colors`. This is done automatically by Bootstrap using the [WCAG 2.0 algorithm](https://getbootstrap.com/docs/5.1/customize/sass/#color-contrast) to make sure the contrast between the text and the background color meets accessibility standards.
 
 For every folder (**`components`**, **`pages`**), there is one `_index.scss` partial which is responsible for importing all the other partials of its folder.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Look at your main `application.scss` file to see how SCSS files are imported. Th
 @import "pages/index";
 ```
 
-Note that the text color of your buttons might change from white to black when you update the colors in `config/colors`. This is done automatically by Bootstrap using the [WCAG 2.0 algorithm](https://getbootstrap.com/docs/5.1/customize/sass/#color-contrast) to make sure the contrast between the text and the background color meets accessibility standards.
+Note that the (text) color of your buttons might change from white to black when you update the colors in `config/colors`. This is done automatically by Bootstrap using the [WCAG 2.0 algorithm](https://getbootstrap.com/docs/5.1/customize/sass/#color-contrast) which makes sure that the contrast between the text and the background color meets accessibility standards.
 
 For every folder (**`components`**, **`pages`**), there is one `_index.scss` partial which is responsible for importing all the other partials of its folder.
 

--- a/config/_colors.scss
+++ b/config/_colors.scss
@@ -2,7 +2,7 @@
 
 // For example:
 $red: #FD1015;
-$blue: #167FFB;
+$blue: #0D6EFD;
 $yellow: #FFC65A;
 $orange: #E67E22;
 $green: #1EDD88;


### PR DESCRIPTION
Steps to update the Rails Frontend guide to use **Bootstrap 5**:

- remove jquery and add the right yarn add import for bootstrap and popperjs
- add the replacement of the initialize file for simple form (which will be removed again once the gem is updated)
- remove the part about the meta tags in the html (since the viewport tag comes with `rails new` and the other one is redundant because Bootstrap 5 is not supported by IE)
- remove the webpack configuration as it's not needed anymore
- I also added a note about why the colors of the buttons change (because of an accessibility algorithm). I think it's quite interesting but let me know if I should remove it again