### PR TITLE
remove outdated simple form instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ bundle install
 rails generate simple_form:install --bootstrap
 ```
 
-Replace **all the content** of your `config/initializers/simple_form_bootstrap.rb` file with [this](https://github.com/heartcombo/simple_form-bootstrap/blob/main/config/initializers/simple_form_bootstrap.rb).
-
 Then replace Rails' stylesheets by Le Wagon's stylesheets:
 
 ```


### PR DESCRIPTION
Now that the[ initializer](https://github.com/heartcombo/simple_form/blob/main/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb) of Simple Form comes with the updated code for Bootstrap 5 we can remove the extra instructions in the lectures and templates 🙌