### PR TITLE
Fix gem versions to delete font awesome sprockets and fix rails templ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Ensure you have the following gems in your Rails `Gemfile`
 
 ```ruby
 # Gemfile
-gem 'autoprefixer-rails'
-gem 'font-awesome-sass', '~> 5.6.1'
+gem 'autoprefixer-rails', '10.2.5'
+gem 'font-awesome-sass'
 gem 'simple_form', github: 'heartcombo/simple_form'
 ```
 

--- a/application.scss
+++ b/application.scss
@@ -5,7 +5,6 @@
 
 // External libraries
 @import "bootstrap/scss/bootstrap";
-@import "font-awesome-sprockets";
 @import "font-awesome";
 
 // Your CSS partials


### PR DESCRIPTION
Hi @dmilon 

I changed the gem versions to the [same ones](https://github.com/lewagon/rails-templates/blob/master/devise.rb#L9-L10) as we use in the Rails templates because this way we can delete the `font-awesome-sprockets` again which right now breaks the rails templates.

By not specifying the font awesome version we can also use the latest syntax (of version 6) (which is the default one when searching for an icon on font awesome).
<img width="1440" alt="Screenshot 2022-05-11 at 14 31 57" src="https://user-images.githubusercontent.com/28513469/167850515-d4d83e45-dfa3-4493-9531-050d66317bba.png">


Let me know what you think :) 