### PR TITLE
Change link for Bootstrap variables to override

### DIFF
--- a/config/_bootstrap_variables.scss
+++ b/config/_bootstrap_variables.scss
@@ -1,13 +1,14 @@
 // This is where you override default Bootstrap variables
-// 1. All Bootstrap variables are here => https://github.com/twbs/bootstrap/blob/master/scss/_variables.scss
+// 1. Find all Bootstrap variables that you can override at the end of each component's documentation under the `Variable` anchor
+// e.g. here are the ones you can override for the navbar https://getbootstrap.com/docs/5.1/components/navbar/#variables
 // 2. These variables are defined with default value (see https://robots.thoughtbot.com/sass-default)
 // 3. You can override them below!
 
 // General style
-$font-family-sans-serif:  $body-font;
-$headings-font-family:    $headers-font;
-$body-bg:                 $light-gray;
-$font-size-base: 1rem;
+$font-family-sans-serif: $body-font;
+$headings-font-family:   $headers-font;
+$body-bg:                $light-gray;
+$font-size-base:         1rem;
 
 // Colors
 $body-color: $gray;

--- a/config/_bootstrap_variables.scss
+++ b/config/_bootstrap_variables.scss
@@ -1,6 +1,6 @@
 // This is where you override default Bootstrap variables
-// 1. Find all Bootstrap variables that you can override at the end of each component's documentation under the `Variable` anchor
-// e.g. here are the ones you can override for the navbar https://getbootstrap.com/docs/5.1/components/navbar/#variables
+// 1. Find all Bootstrap variables that you can override at the end of each component's documentation under the `Sass variables` anchor
+// e.g. here are the ones you can override for the navbar https://getbootstrap.com/docs/5.2/components/navbar/#sass-variables
 // 2. These variables are defined with default value (see https://robots.thoughtbot.com/sass-default)
 // 3. You can override them below!
 


### PR DESCRIPTION
Fixes lewagon/teachers#866

Indeed, the link we show in the comment does list all Bootstrap variables but not all of these can be overridden out of the box. It is more explicit to direct students to the documentation so they can find all the variables which can be overridden there (eg [here](https://getbootstrap.com/docs/5.2/components/navbar/#sass-variables) for the navbar).

What do you think about this?