### PR TITLE
Remove specific path from simple form gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gem "sassc-rails"
 # Add those ones
 gem "autoprefixer-rails"
 gem "font-awesome-sass", "~> 6.1"
-gem "simple_form", github: "heartcombo/simple_form"
+gem "simple_form"
 ```
 
 Add this line to `assets.rb`:
@@ -30,8 +30,6 @@ Add this line to `assets.rb`:
 # Add additional assets to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 ```
-
-⚠ To this day (March, 9th, 2022), Simple Form support of Bootstrap 5 has been merged in `main` but has not been released yet. To use a version of Simple Form which supports Bootstrap 5, we need to install the gem from GitHub and we've added the specific `components/_form_legend_clear.scss` partial in our stylesheets.
 
 In your terminal, generate Simple Form Bootstrap config:
 


### PR DESCRIPTION
I removed the specific path from the simple form gem instructions and also the info about it. As far as I can tell from the [closed PRs](https://github.com/heartcombo/simple_form/pulls?q=is%3Apr+is%3Aclosed) on simple form the other issue mentioned here has not been addressed yet so I left the `form_legend_clear.scss` file here for now.