### PR TITLE
Set border radius variables

### DIFF
--- a/config/_bootstrap_variables.scss
+++ b/config/_bootstrap_variables.scss
@@ -19,8 +19,10 @@ $danger:     $red;
 $warning:    $orange;
 
 // Buttons & inputs' radius
-$border-radius:    2px;
-$border-radius-lg: 2px;
-$border-radius-sm: 2px;
+$border-radius:               .125rem;
+$border-radius-sm:            .125rem;
+$border-radius-lg:            .25rem;
+$border-radius-xl:            .5rem;
+$border-radius-xxl:           1rem;
 
 // Override other variables below!

--- a/config/_bootstrap_variables.scss
+++ b/config/_bootstrap_variables.scss
@@ -19,8 +19,8 @@ $danger:     $red;
 $warning:    $orange;
 
 // Buttons & inputs' radius
+$border-radius-sm:            .0625rem;
 $border-radius:               .125rem;
-$border-radius-sm:            .125rem;
 $border-radius-lg:            .25rem;
 $border-radius-xl:            .5rem;
 $border-radius-xxl:           1rem;


### PR DESCRIPTION
It would also be possible to customize the `button` and `input` border radius properties separately, but that felt too confusing for students and likely to create front-ends without so much unification.

So, I've taken the defaults from Bootstrap:

```scss
$border-radius:               .375rem;
$border-radius-sm:            .25rem;
$border-radius-lg:            .5rem;
$border-radius-xl:            1rem;
$border-radius-xxl:           2rem;
$border-radius-pill:          50rem;

$btn-border-radius:           var(--#{$prefix}border-radius);
$btn-border-radius-sm:        var(--#{$prefix}border-radius-sm);
$btn-border-radius-lg:        var(--#{$prefix}border-radius-lg);

/* ^ same thing exists for `input` too */
```

And basically just lowered the defaults. I set the default to `.125rem`, which assuming a standard font size of `16px`, should equate to a default border radius of `2px`, which was our old default (it's much better practice to declare this in `rem` in case the user changes their font size, but hopefully this won't be too confusing for students).

resolve https://github.com/lewagon/teachers/issues/2459